### PR TITLE
Fix redundant error when starting hub after first start failed

### DIFF
--- a/src/projects/ngrx-signalr-core/src/lib/SignalRHub.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/SignalRHub.ts
@@ -54,7 +54,7 @@ export class SignalRHub implements ISignalRHub {
         this._startSubject.next();
         this._stateSubject.next(connected);
       })
-      .catch((error) => this._startSubject.error(error));
+      .catch((error) => this._errorSubject.next(error));
 
     return this._startSubject.asObservable();
   }
@@ -72,7 +72,7 @@ export class SignalRHub implements ISignalRHub {
         this._stopSubject.next();
         this._stateSubject.next(disconnected);
       })
-      .catch((error) => this._stopSubject.error(error));
+      .catch((error) => this._errorSubject.next(error));
 
     return this._stopSubject.asObservable();
   }


### PR DESCRIPTION
Fixes issue #54.

I propose changing `this._startSubject.error(error))`  to `this._errorSubject.next(error))`.

The result of calling `this._startSubject.error(error))` puts the `_startSubject` into an error state and further calls to `_startSubject.next()` will fail silently, while subscribers to `this._startSubject.asObservable()' will immediately receive the error the error and nothing else.

This causes the startHub$ effect:
```javascript
startHub$ = createEffect(() =>
    this.actions$.pipe(
      ofType(startSignalRHub, reconnectSignalRHub),
      mergeMapHubToAction(({ hub }) => {
        return hub.start().pipe(
          mergeMap((_) => EMPTY),
          catchError((error) =>
            of(signalrError({ hubName: hub.hubName, url: hub.url, error }))
          )
        );
      })
    )
  );
```
to receive, catch, and then dispatch the error on the next attempt to start the hub even though the connection happens successfully without error. 

I haven't experienced the same issues when calling stopHub but I imagine it would make sense to apply the same error handling.