### PR TITLE
add signalrReconnecting action and reconnecting hubstate

### DIFF
--- a/src/projects/ngrx-signalr-core/src/lib/SignalRHub.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/SignalRHub.ts
@@ -8,7 +8,7 @@ import {
 } from "@microsoft/signalr";
 import { Subject, Observable, throwError, from } from "rxjs";
 import { share } from "rxjs/operators";
-import { connected, disconnected } from "./hubStatus";
+import { connected, disconnected, reconnecting } from "./hubStatus";
 import { createConnection } from "./signalr";
 
 export class SignalRHub implements ISignalRHub {

--- a/src/projects/ngrx-signalr-core/src/lib/SignalRHub.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/SignalRHub.ts
@@ -50,6 +50,12 @@ export class SignalRHub implements ISignalRHub {
         this._errorSubject.next(error);
         this._stateSubject.next(disconnected);
       });
+      this._connection.onreconnecting(() => {
+        this._stateSubject.next(reconnecting);
+      });
+      this._connection.onreconnected(() => {
+        this._stateSubject.next(connected);
+      });
     }
 
     return this._connection;

--- a/src/projects/ngrx-signalr-core/src/lib/actions.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/actions.ts
@@ -70,6 +70,14 @@ export const signalrConnected = createAction(
 );
 
 /**
+ * Action dispatched when a hub is at `reconnecting` state.
+ */
+export const signalrReconnecting = createAction(
+  "@ngrx/signalr/reconnecting",
+  props<{ hubName: string; url: string }>()
+);
+
+/**
  * Action dispatched when a hub is at `disconnected` state.
  */
 export const signalrDisconnected = createAction(
@@ -101,6 +109,7 @@ const signalRAction = union({
   reconnectSignalRHub,
   signalrHubFailedToStart,
   signalrConnected,
+  signalrReconnecting,
   signalrDisconnected,
   signalrError,
   hubNotFound,

--- a/src/projects/ngrx-signalr-core/src/lib/effects.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/effects.ts
@@ -22,6 +22,7 @@ import {
   signalrError,
   signalrHubFailedToStart,
   stopSignalRHub,
+  signalrReconnecting,
 } from "./actions";
 import {
   ofHub,
@@ -30,7 +31,7 @@ import {
   mergeMapHubToAction,
 } from "./operators";
 import { Action } from "@ngrx/store";
-import { connected, disconnected } from "./hubStatus";
+import { connected, disconnected, reconnecting } from "./hubStatus";
 import { Observable } from "rxjs";
 import { TypedAction } from "@ngrx/store/src/models";
 
@@ -102,6 +103,14 @@ export class SignalREffects {
             if (state === disconnected) {
               return of(
                 signalrDisconnected({
+                  hubName: action.hubName,
+                  url: action.url,
+                })
+              );
+            }
+            if (state === reconnecting) {
+              return of(
+                signalrReconnecting({
                   hubName: action.hubName,
                   url: action.url,
                 })

--- a/src/projects/ngrx-signalr-core/src/lib/hubStatus.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/hubStatus.ts
@@ -4,6 +4,7 @@ import { HubKeyDefinition } from "./models";
 export const unstarted = "unstarted";
 export const connected = "connected";
 export const disconnected = "disconnected";
+export const reconnecting = "reconnecting";
 
 /**
  * List of given states a SignalR can be.

--- a/src/projects/ngrx-signalr-core/src/lib/hubStatus.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/hubStatus.ts
@@ -13,6 +13,7 @@ export const SignalRStates = {
   unstarted,
   connected,
   disconnected,
+  reconnecting,
 };
 
 /**
@@ -25,6 +26,8 @@ export const toSignalRState = (state: HubConnectionState) => {
       return connected;
     case HubConnectionState.Disconnected:
       return disconnected;
+    case HubConnectionState.Reconnecting:
+      return reconnecting;
   }
 };
 
@@ -34,7 +37,8 @@ export const toSignalRState = (state: HubConnectionState) => {
 export type SignalRHubState =
   | typeof unstarted
   | typeof connected
-  | typeof disconnected;
+  | typeof disconnected
+  | typeof reconnecting;
 
 /**
  * Status definition of a SignalR hub.

--- a/src/projects/ngrx-signalr-core/src/lib/reducer.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/reducer.ts
@@ -4,12 +4,14 @@ import {
   unstarted,
   connected,
   disconnected,
+  reconnecting,
 } from "./hubStatus";
 import { createReducer, on, Action } from "@ngrx/store";
 import {
   createSignalRHub,
   signalrHubUnstarted,
   signalrConnected,
+  signalrReconnecting,
   signalrDisconnected,
 } from "./actions";
 
@@ -61,6 +63,20 @@ const reducer = createReducer<BaseSignalRStoreState>(
           return {
             ...hs,
             state: connected as SignalRHubState,
+          };
+        }
+        return hs;
+      }),
+    };
+  }),
+  on(signalrReconnecting, (state, action) => {
+    return {
+      ...state,
+      hubStatuses: state.hubStatuses.map((hs) => {
+        if (hs.hubName === action.hubName && hs.url === action.url) {
+          return {
+            ...hs,
+            state: reconnecting as SignalRHubState,
           };
         }
         return hs;

--- a/src/projects/ngrx-signalr-core/src/public-api.ts
+++ b/src/projects/ngrx-signalr-core/src/public-api.ts
@@ -11,6 +11,7 @@ export {
   reconnectSignalRHub,
   signalrHubFailedToStart,
   signalrConnected,
+  signalrReconnecting,
   signalrDisconnected,
   signalrError,
   hubNotFound,


### PR DESCRIPTION
This PR makes it possible to create an effect to, for example, show an overlay over the application during reconnecting of the hub.