### PR TITLE
feature: add connectionId to the signalrConnected action

### DIFF
--- a/src/projects/ngrx-signalr-core/src/lib/SignalRHub.interface.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/SignalRHub.interface.ts
@@ -19,6 +19,11 @@ export interface ISignalRHub {
   options: IHttpConnectionOptions | undefined;
 
   /**
+   * Connection ID of the client.
+   */
+  connectionId: string | undefined;
+
+  /**
    * Observable that gives info when a start event occured.
    */
   start$: Observable<void>;

--- a/src/projects/ngrx-signalr-core/src/lib/SignalRHub.testing.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/SignalRHub.testing.ts
@@ -4,59 +4,63 @@ import { IHttpConnectionOptions } from "@microsoft/signalr";
 import { connected, disconnected } from "./hubStatus";
 
 export abstract class SignalRTestingHub implements ISignalRHub {
-    private _startSubject = new Subject<void>();
-    private _stopSubject = new Subject<void>();
-    private _stateSubject = new Subject<string>();
-    private _errorSubject = new Subject<Error | undefined>();
-    private _subjects: { [eventName: string]: Subject<any> } = {};
+  private _startSubject = new Subject<void>();
+  private _stopSubject = new Subject<void>();
+  private _stateSubject = new Subject<string>();
+  private _errorSubject = new Subject<Error | undefined>();
+  private _subjects: { [eventName: string]: Subject<any> } = {};
 
-    start$: Observable<void>;
-    stop$: Observable<void>;
-    state$: Observable<string>;
-    error$: Observable<Error | undefined>;
+  start$: Observable<void>;
+  stop$: Observable<void>;
+  state$: Observable<string>;
+  error$: Observable<Error | undefined>;
 
-    get connectionId() {
-        return undefined;
+  get connectionId() {
+    return undefined;
+  }
+
+  constructor(
+    public hubName: string,
+    public url: string,
+    public options: IHttpConnectionOptions | undefined
+  ) {
+    this.start$ = this._startSubject.asObservable();
+    this.stop$ = this._stopSubject.asObservable();
+    this.state$ = this._stateSubject.asObservable();
+    this.error$ = this._errorSubject.asObservable();
+  }
+
+  start() {
+    timer(100).subscribe((_) => {
+      this._startSubject.next();
+      this._stateSubject.next(connected);
+    });
+
+    return this._startSubject.asObservable();
+  }
+
+  stop() {
+    timer(100).subscribe((_) => {
+      this._stopSubject.next();
+      this._stateSubject.next(disconnected);
+    });
+
+    return this._stopSubject.asObservable();
+  }
+
+  abstract on<T>(eventName: string): Observable<T>;
+  abstract off(eventName: string): void;
+  abstract stream<T>(methodName: string, ...args: any[]): Observable<T>;
+  abstract send<T>(methodName: string, ...args: any[]): Observable<T>;
+  abstract sendStream<T>(methodName: string, observable: Observable<T>): void;
+
+  hasSubscriptions(): boolean {
+    for (let key in this._subjects) {
+      if (this._subjects.hasOwnProperty(key)) {
+        return true;
+      }
     }
 
-    constructor(public hubName: string, public url: string, public options: IHttpConnectionOptions | undefined) {
-        this.start$ = this._startSubject.asObservable();
-        this.stop$ = this._stopSubject.asObservable();
-        this.state$ = this._stateSubject.asObservable();
-        this.error$ = this._errorSubject.asObservable();
-    }
-
-    start() {
-        timer(100).subscribe((_) => {
-            this._startSubject.next();
-            this._stateSubject.next(connected);
-        });
-
-        return this._startSubject.asObservable();
-    }
-
-    stop() {
-        timer(100).subscribe((_) => {
-            this._stopSubject.next();
-            this._stateSubject.next(disconnected);
-        });
-
-        return this._stopSubject.asObservable();
-    }
-
-    abstract on<T>(eventName: string): Observable<T>;
-    abstract off(eventName: string): void;
-    abstract stream<T>(methodName: string, ...args: any[]): Observable<T>;
-    abstract send<T>(methodName: string, ...args: any[]): Observable<T>;
-    abstract sendStream<T>(methodName: string, observable: Observable<T>): void;
-
-    hasSubscriptions(): boolean {
-        for (let key in this._subjects) {
-            if (this._subjects.hasOwnProperty(key)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    return false;
+  }
 }

--- a/src/projects/ngrx-signalr-core/src/lib/SignalRHub.testing.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/SignalRHub.testing.ts
@@ -4,59 +4,59 @@ import { IHttpConnectionOptions } from "@microsoft/signalr";
 import { connected, disconnected } from "./hubStatus";
 
 export abstract class SignalRTestingHub implements ISignalRHub {
-  private _startSubject = new Subject<void>();
-  private _stopSubject = new Subject<void>();
-  private _stateSubject = new Subject<string>();
-  private _errorSubject = new Subject<Error | undefined>();
-  private _subjects: { [eventName: string]: Subject<any> } = {};
+    private _startSubject = new Subject<void>();
+    private _stopSubject = new Subject<void>();
+    private _stateSubject = new Subject<string>();
+    private _errorSubject = new Subject<Error | undefined>();
+    private _subjects: { [eventName: string]: Subject<any> } = {};
 
-  start$: Observable<void>;
-  stop$: Observable<void>;
-  state$: Observable<string>;
-  error$: Observable<Error | undefined>;
+    start$: Observable<void>;
+    stop$: Observable<void>;
+    state$: Observable<string>;
+    error$: Observable<Error | undefined>;
 
-  constructor(
-    public hubName: string,
-    public url: string,
-    public options: IHttpConnectionOptions | undefined
-  ) {
-    this.start$ = this._startSubject.asObservable();
-    this.stop$ = this._stopSubject.asObservable();
-    this.state$ = this._stateSubject.asObservable();
-    this.error$ = this._errorSubject.asObservable();
-  }
-
-  start() {
-    timer(100).subscribe((_) => {
-      this._startSubject.next();
-      this._stateSubject.next(connected);
-    });
-
-    return this._startSubject.asObservable();
-  }
-
-  stop() {
-    timer(100).subscribe((_) => {
-      this._stopSubject.next();
-      this._stateSubject.next(disconnected);
-    });
-
-    return this._stopSubject.asObservable();
-  }
-
-  abstract on<T>(eventName: string): Observable<T>;
-  abstract off(eventName: string): void;
-  abstract stream<T>(methodName: string, ...args: any[]): Observable<T>;
-  abstract send<T>(methodName: string, ...args: any[]): Observable<T>;
-  abstract sendStream<T>(methodName: string, observable: Observable<T>): void;
-
-  hasSubscriptions(): boolean {
-    for (let key in this._subjects) {
-      if (this._subjects.hasOwnProperty(key)) {
-        return true;
-      }
+    get connectionId() {
+        return undefined;
     }
 
-    return false;
-  }
+    constructor(public hubName: string, public url: string, public options: IHttpConnectionOptions | undefined) {
+        this.start$ = this._startSubject.asObservable();
+        this.stop$ = this._stopSubject.asObservable();
+        this.state$ = this._stateSubject.asObservable();
+        this.error$ = this._errorSubject.asObservable();
+    }
+
+    start() {
+        timer(100).subscribe((_) => {
+            this._startSubject.next();
+            this._stateSubject.next(connected);
+        });
+
+        return this._startSubject.asObservable();
+    }
+
+    stop() {
+        timer(100).subscribe((_) => {
+            this._stopSubject.next();
+            this._stateSubject.next(disconnected);
+        });
+
+        return this._stopSubject.asObservable();
+    }
+
+    abstract on<T>(eventName: string): Observable<T>;
+    abstract off(eventName: string): void;
+    abstract stream<T>(methodName: string, ...args: any[]): Observable<T>;
+    abstract send<T>(methodName: string, ...args: any[]): Observable<T>;
+    abstract sendStream<T>(methodName: string, observable: Observable<T>): void;
+
+    hasSubscriptions(): boolean {
+        for (let key in this._subjects) {
+            if (this._subjects.hasOwnProperty(key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/projects/ngrx-signalr-core/src/lib/SignalRHub.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/SignalRHub.ts
@@ -24,6 +24,10 @@ export class SignalRHub implements ISignalRHub {
   state$: Observable<string>;
   error$: Observable<Error | undefined>;
 
+  get connectionId() {
+    return this._connection?.connectionId ?? undefined;
+  }
+
   constructor(
     public hubName: string,
     public url: string,

--- a/src/projects/ngrx-signalr-core/src/lib/actions.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/actions.ts
@@ -66,7 +66,7 @@ export const signalrHubFailedToStart = createAction(
  */
 export const signalrConnected = createAction(
   "@ngrx/signalr/connected",
-  props<{ hubName: string; url: string }>()
+  props<{ hubName: string; url: string; connectionId: string | undefined }>()
 );
 
 /**

--- a/src/projects/ngrx-signalr-core/src/lib/effects.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/effects.ts
@@ -97,7 +97,7 @@ export class SignalREffects {
           mergeMap((state) => {
             if (state === connected) {
               return of(
-                signalrConnected({ hubName: action.hubName, url: action.url })
+                signalrConnected({ hubName: action.hubName, url: action.url, connectionId: hub.connectionId })
               );
             }
             if (state === disconnected) {


### PR DESCRIPTION
In our app we need to get hold of the connection ID in the connected action. This adds this so that we do not need ugly workarounds.