### PR TITLE
fix duplicate subscription on reconnect: adds new action signalRrecon…

### DIFF
--- a/src/projects/ngrx-signalr-core/package.json
+++ b/src/projects/ngrx-signalr-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngrx-signalr-core",
-  "version": "15.1.1",
+  "version": "15.1.2",
   "description": "A library to handle realtime SignalR Core events using angular and rxjs",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/projects/ngrx-signalr-core/src/lib/SignalRHub.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/SignalRHub.ts
@@ -8,7 +8,7 @@ import {
 } from "@microsoft/signalr";
 import { Subject, Observable, throwError, from } from "rxjs";
 import { share } from "rxjs/operators";
-import { connected, disconnected, reconnecting } from "./hubStatus";
+import { connected, disconnected, reconnecting, reconnected } from "./hubStatus";
 import { createConnection } from "./signalr";
 
 export class SignalRHub implements ISignalRHub {
@@ -60,7 +60,7 @@ export class SignalRHub implements ISignalRHub {
         this._stateSubject.next(reconnecting);
       });
       this._connection.onreconnected(() => {
-        this._stateSubject.next(connected);
+        this._stateSubject.next(reconnected);
       });
     }
 

--- a/src/projects/ngrx-signalr-core/src/lib/actions.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/actions.ts
@@ -78,6 +78,14 @@ export const signalrReconnecting = createAction(
 );
 
 /**
+ * Action dispatched when a hub is `reconnected`.
+ */
+export const signalrReconnected = createAction(
+  "@ngrx/signalr/reconnected",
+  props<{ hubName: string; url: string }>()
+);
+
+/**
  * Action dispatched when a hub is at `disconnected` state.
  */
 export const signalrDisconnected = createAction(
@@ -110,6 +118,7 @@ const signalRAction = union({
   signalrHubFailedToStart,
   signalrConnected,
   signalrReconnecting,
+  signalrReconnected,
   signalrDisconnected,
   signalrError,
   hubNotFound,

--- a/src/projects/ngrx-signalr-core/src/lib/effects.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/effects.ts
@@ -23,6 +23,7 @@ import {
   signalrHubFailedToStart,
   stopSignalRHub,
   signalrReconnecting,
+  signalrReconnected,
 } from "./actions";
 import {
   ofHub,
@@ -31,7 +32,7 @@ import {
   mergeMapHubToAction,
 } from "./operators";
 import { Action } from "@ngrx/store";
-import { connected, disconnected, reconnecting } from "./hubStatus";
+import { connected, disconnected, reconnecting, reconnected } from "./hubStatus";
 import { Observable } from "rxjs";
 import { TypedAction } from "@ngrx/store/src/models";
 
@@ -111,6 +112,14 @@ export class SignalREffects {
             if (state === reconnecting) {
               return of(
                 signalrReconnecting({
+                  hubName: action.hubName,
+                  url: action.url,
+                })
+              );
+            }
+            if (state === reconnected) {
+              return of(
+                signalrReconnected({
                   hubName: action.hubName,
                   url: action.url,
                 })

--- a/src/projects/ngrx-signalr-core/src/public-api.ts
+++ b/src/projects/ngrx-signalr-core/src/public-api.ts
@@ -12,6 +12,7 @@ export {
   signalrHubFailedToStart,
   signalrConnected,
   signalrReconnecting,
+  signalrReconnected,
   signalrDisconnected,
   signalrError,
   hubNotFound,


### PR DESCRIPTION
Adding new action (and state) reconnected avoids duplicated subscription when signalr conection drops and start reconnecting phase.